### PR TITLE
cleanup constants, provide commands optionally with job metadata, allow loading of external behaviours

### DIFF
--- a/ippserver/__main__.py
+++ b/ippserver/__main__.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import argparse
 import logging
+import importlib
 import sys, os.path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -36,17 +37,22 @@ def parse_args(args=None):
 	parser_command = parser_action.add_parser('run', help='Run a command when recieving a print job')
 	parser_command.add_argument('command', nargs=argparse.REMAINDER, metavar='COMMAND', help='Command to run')
 	parser_command.add_argument('--pdf', action='store_true', default=False, help=pdf_help)
+	parser_command.add_argument('--env', action='store_true', default=False, help="Store Job attributes in environment (IPP_JOB_ATTRIBUTES)")
 
 	parser_saverun = parser_action.add_parser('saveandrun', help='Write any print jobs to disk and the run a command on them')
 	parser_saverun.add_argument('--pdf', action='store_true', default=False, help=pdf_help)
+	parser_saverun.add_argument('--env', action='store_true', default=False, help="Store Job attributes in environment (IPP_JOB_ATTRIBUTES)")
 	parser_saverun.add_argument('directory', metavar='DIRECTORY', help='Directory to save files into')
 	parser_saverun.add_argument('command', nargs=argparse.REMAINDER, metavar='COMMAND', help='Command to run (the filename will be added at the end)')
 
 	parser_command = parser_action.add_parser('reject', help='Respond to all print jobs with job-canceled-at-device')
 
-	parser_command = parser_action.add_parser('pc2paper', help='Post print jobs usign http://www.pc2paper.org/')
+	parser_command = parser_action.add_parser('pc2paper', help='Post print jobs using http://www.pc2paper.org/')
 	parser_command.add_argument('--pdf', action='store_true', default=False, help=pdf_help)
-	parser_command.add_argument('--config', metavar='CONFIG', help='File containging an address to send to, in json format')
+	parser_command.add_argument('--config', metavar='CONFIG', help='File containing an address to send to, in json format')
+	parser_loader = parser_action.add_parser('load', help='Load own behaviour')
+	parser_loader.add_argument('path', nargs=1, metavar=['PATH'], help='Module implementing behaviour')
+	parser_loader.add_argument('command', nargs=argparse.REMAINDER, metavar='COMMAND', help='Arguments for the module')
 
 	return parser.parse_args(args)
 
@@ -58,10 +64,12 @@ def behaviour_from_parsed_args(args):
 	if args.action == 'run':
 		return behaviour.RunCommandPrinter(
 			command=args.command,
+			use_env=args.env,
 			filename_ext='pdf' if args.pdf else 'ps')
 	if args.action == 'saveandrun':
 		return behaviour.SaveAndRunPrinter(
 			command=args.command,
+			use_env=args.env,
 			directory=args.directory,
 			filename_ext='pdf' if args.pdf else 'ps')
 	if args.action == 'pc2paper':
@@ -69,6 +77,9 @@ def behaviour_from_parsed_args(args):
 		return behaviour.PostageServicePrinter(
 			service_api=pc2paper_config,
 			filename_ext='pdf' if args.pdf else 'ps')
+	if args.action == 'load':
+		module, name = args.path[0].rsplit(".", 1)
+		return getattr(importlib.import_module(module), name)(*args.command)
 	if args.action == 'reject':
 		return behaviour.RejectAllPrinter()
 	raise RuntimeError(args)

--- a/ippserver/behaviour.py
+++ b/ippserver/behaviour.py
@@ -12,12 +12,9 @@ import time
 import uuid
 
 from . import parsers
-from .constants import JobStateEnum
-from .constants import OperationEnum
-from .constants import StatusCodeEnum
+from .constants import JobStateEnum, OperationEnum, StatusCodeEnum, SectionEnum, TagEnum
 from .ppd import BasicPostscriptPPD, BasicPdfPPD
 from .request import IppRequest
-from .request import SectionEnum, TagEnum
 
 
 def get_job_id(req):

--- a/ippserver/constants.py
+++ b/ippserver/constants.py
@@ -3,10 +3,58 @@ from __future__ import absolute_import
 from __future__ import print_function
 from __future__ import unicode_literals
 
+try:
+	from enum import Enum
+except ImportError:
+	Enum = object
+
 import logging
 
 
-class StatusCodeEnum(object):
+class SectionEnum(Enum):
+	# delimiters (sections)
+	SECTIONS              = 0x00
+	SECTIONS_MASK         = 0xf0
+	operation   = 0x01
+	job         = 0x02
+	END         = 0x03
+	printer     = 0x04
+	unsupported = 0x05
+
+	@classmethod
+	def is_section_tag(cls, tag):
+		return (tag & cls.SECTIONS_MASK) == cls.SECTIONS
+
+
+class TagEnum(Enum):
+	unsupported_value     = 0x10
+	unknown_value         = 0x12
+	no_value              = 0x13
+
+	# int types
+	integer               = 0x21
+	boolean               = 0x22
+	enum                  = 0x23
+
+	# string types
+	octet_str             = 0x30
+	datetime_str          = 0x31
+	resolution            = 0x32
+	range_of_integer      = 0x33
+	text_with_language    = 0x35
+	name_with_language    = 0x36
+
+	text_without_language = 0x41
+	name_without_language = 0x42
+	keyword               = 0x44
+	uri                   = 0x45
+	uri_scheme            = 0x46
+	charset               = 0x47
+	natural_language      = 0x48
+	mime_media_type       = 0x49
+
+
+class StatusCodeEnum(Enum):
 	# https://tools.ietf.org/html/rfc2911#section-13.1
 	ok = 0x0000
 	server_error_internal_error = 0x0500
@@ -14,7 +62,7 @@ class StatusCodeEnum(object):
 	server_error_job_canceled = 0x508
 
 
-class OperationEnum(object):
+class OperationEnum(Enum):
 	# https://tools.ietf.org/html/rfc2911#section-4.4.15
 	print_job = 0x0002
 	validate_job = 0x0004
@@ -29,7 +77,7 @@ class OperationEnum(object):
 	cups_get_default = 0x4001
 	cups_list_all_printers = 0x4002
 
-class JobStateEnum(object):
+class JobStateEnum(Enum):
 	# https://tools.ietf.org/html/rfc2911#section-4.3.7
 	pending = 3
 	pending_held = 4

--- a/ippserver/request.py
+++ b/ippserver/request.py
@@ -9,49 +9,7 @@ import operator
 import itertools
 
 from .parsers import read_struct, write_struct
-
-class SectionEnum(object):
-	# delimiters (sections)
-	SECTIONS              = 0x00
-	SECTIONS_MASK         = 0xf0
-	operation   = 0x01
-	job         = 0x02
-	END         = 0x03
-	printer     = 0x04
-	unsupported = 0x05
-
-	@classmethod
-	def is_section_tag(cls, tag):
-		return (tag & cls.SECTIONS_MASK) == cls.SECTIONS
-
-
-class TagEnum(object):
-	unsupported_value     = 0x10
-	unknown_value         = 0x12
-	no_value              = 0x13
-
-	# int types
-	integer               = 0x21
-	boolean               = 0x22
-	enum                  = 0x23
-
-	# string types
-	octet_str             = 0x30
-	datetime_str          = 0x31
-	resolution            = 0x32
-	range_of_integer      = 0x33
-	text_with_language    = 0x35
-	name_with_language    = 0x36
-
-	text_without_language = 0x41
-	name_without_language = 0x42
-	keyword               = 0x44
-	uri                   = 0x45
-	uri_scheme            = 0x46
-	charset               = 0x47
-	natural_language      = 0x48
-	mime_media_type       = 0x49
-
+from .constants import SectionEnum, TagEnum
 
 class IppRequest(object):
 	def __init__(self, version, opid_or_status, request_id, attributes):

--- a/ippserver/request.py
+++ b/ippserver/request.py
@@ -137,6 +137,16 @@ class IppRequest(object):
 					f.write(value)
 		write_struct(f, b'>B', SectionEnum.END)
 
+	def attributes_to_multilevel(self, section=None):
+		ret = {}
+		for key in self._attributes.keys():
+			if section and section != key[0]:
+				continue
+			ret.setdefault(key[0], {})
+			ret[key[0]].setdefault(key[1], {})
+			ret[key[0]][key[1]][key[2]] = self._attributes[key]
+		return ret
+
 	def lookup(self, section, name, tag):
 		return self._attributes[section, name, tag]
 


### PR DESCRIPTION
This patch bases on my former patch (sry for that, splitting would have resulted in a broken version).

It allows loading arbitrary behaviours and optionally passes  job information in the environment to the called processes.
Also all Enums are moved to constants and are basing on the enum class if it is available otherwise on object